### PR TITLE
Fix deployment for Mac, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
     upstream connect error or disconnect/reset before headers. reset reason: remote reset
     ```
 
-- **Sample Call:**
-
-  `curl -v -d '{"userid":1, "product":"Fridge", "total":500}' -H "Content-Type: application/json" -X POST 'localhost:50000/v1/orders'`
+## Sample Call
+```
+curl -v -d '{"userid":1, "product":"Fridge", "total":500}' -H "Content-Type: application/json" -X POST 'localhost:50000/v1/orders' -H 'token: abc'
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=users
     ports:
-      - 5000:5432
+      - 5002:5432
   orders-database:
     build: ./database/orders
     environment:
@@ -14,7 +14,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=orders
     ports:
-      - 5001:5432
+      - 5003:5432
 
   envoy:
     build: ./envoy

--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -79,7 +79,7 @@ static_resources:
                   address:
                     socket_address:
                       address: auth
-                      port_value: 5000
+                      port_value: 5005
     - name: users-grpc
       type: LOGICAL_DNS
       lb_policy: ROUND_ROBIN

--- a/services/auth/main.go
+++ b/services/auth/main.go
@@ -13,7 +13,7 @@ func main() {
 	s := grpc.NewServer()
 	auth.RegisterAuthorizationServer(s, &server.Server{})
 
-	lis, err := net.Listen("tcp", ":5000")
+	lis, err := net.Listen("tcp", ":5005")
 	if err != nil {
 		return
 	}

--- a/services/orders/README.md
+++ b/services/orders/README.md
@@ -1,7 +1,7 @@
 ### Environment variables
 
 ```shell
-export DATABASE_URI=postgres://postgres:postgres@localhost:5001/orders
+export DATABASE_URI=postgres://postgres:postgres@localhost:5003/orders
 export USER_SERVICE_ADDR=http://0.0.0.0:50000
 ```
 

--- a/services/users/README.md
+++ b/services/users/README.md
@@ -1,7 +1,7 @@
 ### Environment variables
 
 ```shell
-export DATABASE_URI=postgres://postgres:postgres@localhost:5000/users
+export DATABASE_URI=postgres://postgres:postgres@localhost:5002/users
 ```
 
 ### grpcurl


### PR DESCRIPTION
On MacOS port 5000 is used by some system stuff, so this PR makes it not use 5000 here. I also include the necessary auth header in the README.